### PR TITLE
local: move "Stdout/err" to "node.Config"

### DIFF
--- a/local/network.go
+++ b/local/network.go
@@ -127,11 +127,11 @@ func NewNodeProcess(config node.Config, args ...string) (NodeProcess, error) {
 	// Start the AvalancheGo node and pass it the flags defined above
 	cmd := exec.Command(localNodeConfig.BinaryPath, args...)
 	// Optionally re-direct stdout and stderr
-	if localNodeConfig.Stdout != nil {
-		cmd.Stdout = localNodeConfig.Stdout
+	if config.Stdout != nil {
+		cmd.Stdout = config.Stdout
 	}
-	if localNodeConfig.Stderr != nil {
-		cmd.Stderr = localNodeConfig.Stderr
+	if config.Stderr != nil {
+		cmd.Stderr = config.Stderr
 	}
 	return &nodeProcessImpl{cmd: cmd}, nil
 }

--- a/local/node.go
+++ b/local/node.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"io"
 	"os/exec"
 	"syscall"
 
@@ -21,10 +20,6 @@ var (
 type NodeConfig struct {
 	// What type of node this is
 	BinaryPath string `json:"binaryPath"`
-	// If non-nil, direct this node's stdout here
-	Stdout io.Writer
-	// If non-nil, direct this node's stderr here
-	Stderr io.Writer
 }
 
 // Use an interface so we can mock running

--- a/network/node/node.go
+++ b/network/node/node.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/ava-labs/avalanche-network-runner/api"
 	"github.com/ava-labs/avalanchego/config"
@@ -47,6 +48,10 @@ type Config struct {
 	ConfigFile string `json:"configFile"`
 	// May be nil.
 	CChainConfigFile string `json:"cChainConfigFile"`
+	// If non-nil, direct stdout here
+	Stdout io.Writer
+	// If non-nil, direct stderr here
+	Stderr io.Writer
 }
 
 // Returns an error if this config is invalid


### PR DESCRIPTION
https://github.com/ava-labs/avalanche-network-runner/pull/58 changed `ImplSpecificConfig` to `[]byte`, so `io.Writer` with JSON tag doesn't make sense anymore. Move to the top level config.