### PR TITLE
Fixing API and P2P port flag from nodeConfig

### DIFF
--- a/local/network.go
+++ b/local/network.go
@@ -404,22 +404,22 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 		}
 	}
 
-	// Use random free API port, unless given in config file or node config flag
+	// Use random free API port, unless given in node config flags or config file
 	var (
 		apiPort uint16
 		err     error
 	)
-	if apiPortIntf, ok := configFile[config.HTTPPortKey]; ok {
-		if apiPortFromConfigFile, ok := apiPortIntf.(float64); ok {
-			apiPort = uint16(apiPortFromConfigFile)
-		} else {
-			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.HTTPPortKey, apiPortIntf)
-		}
-	} else if apiPortIntf, ok := nodeConfig.Flags[config.HTTPPortKey]; ok {
+	if apiPortIntf, ok := nodeConfig.Flags[config.HTTPPortKey]; ok {
 		if apiPortFromNodeConfigFlags, ok := apiPortIntf.(int); ok {
 			apiPort = uint16(apiPortFromNodeConfigFlags)
 		} else {
 			return nil, fmt.Errorf("expected flag %q to be int but got %T", config.HTTPPortKey, apiPortIntf)
+		}
+	} else if apiPortIntf, ok := configFile[config.HTTPPortKey]; ok {
+		if apiPortFromConfigFile, ok := apiPortIntf.(float64); ok {
+			apiPort = uint16(apiPortFromConfigFile)
+		} else {
+			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.HTTPPortKey, apiPortIntf)
 		}
 	} else {
 		// Use a random free port.
@@ -430,19 +430,19 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 		}
 	}
 
-	// Use a random free P2P (staking) port, unless given in config file or node config flag
+	// Use a random free P2P (staking) port, unless given in node config flags or config file
 	var p2pPort uint16
-	if p2pPortIntf, ok := configFile[config.StakingPortKey]; ok {
-		if p2pPortFromConfigFile, ok := p2pPortIntf.(float64); ok {
-			p2pPort = uint16(p2pPortFromConfigFile)
-		} else {
-			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.StakingPortKey, p2pPortIntf)
-		}
-	} else if p2pPortIntf, ok := nodeConfig.Flags[config.StakingPortKey]; ok {
+	if p2pPortIntf, ok := nodeConfig.Flags[config.StakingPortKey]; ok {
 		if p2pPortFromNodeConfigFlags, ok := p2pPortIntf.(int); ok {
 			p2pPort = uint16(p2pPortFromNodeConfigFlags)
 		} else {
 			return nil, fmt.Errorf("expected flag %q to be int but got %T", config.StakingPortKey, p2pPortIntf)
+		}
+	} else if p2pPortIntf, ok := configFile[config.StakingPortKey]; ok {
+		if p2pPortFromConfigFile, ok := p2pPortIntf.(float64); ok {
+			p2pPort = uint16(p2pPortFromConfigFile)
+		} else {
+			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.StakingPortKey, p2pPortIntf)
 		}
 	} else {
 		// Use a random free port.

--- a/local/network.go
+++ b/local/network.go
@@ -430,7 +430,7 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 		if p2pPortFromConfig, ok := p2pPortIntf.(float64); ok {
 			p2pPort = uint16(p2pPortFromConfig)
 		} else {
-			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.HTTPPortKey, p2pPortIntf)
+			return nil, fmt.Errorf("expected flag %q to be float64 but got %T", config.StakingPortKey, p2pPortIntf)
 		}
 	} else {
 		// Use a random free port.
@@ -457,6 +457,26 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 			ln.log.Warn("The flag %s has been provided. This can create conflicts with the runner. The suggestion is to remove this flag", flagName)
 		}
 		flags = append(flags, fmt.Sprintf("--%s=%v", flagName, flagVal))
+	}
+
+	// Overwriting API port if it is also present in nodeConfig's flag
+	if apiPortIntf, ok := nodeConfig.Flags[config.HTTPPortKey]; ok {
+		if apiPortFromConfig, ok := apiPortIntf.(int); ok {
+			apiPort = uint16(apiPortFromConfig)
+			flags = append(flags, fmt.Sprintf("--%s=%d", config.HTTPPortKey, apiPort))
+		} else {
+			return nil, fmt.Errorf("expected flag %q to be int but got %T", config.HTTPPortKey, apiPortIntf)
+		}
+	}
+
+	// Overwriting Staking port if it is also present in nodeConfig's flag
+	if p2pPortIntf, ok := nodeConfig.Flags[config.StakingPortKey]; ok {
+		if p2pPortFromConfig, ok := p2pPortIntf.(int); ok {
+			p2pPort = uint16(p2pPortFromConfig)
+			flags = append(flags, fmt.Sprintf("--%s=%d", config.StakingPortKey, p2pPort))
+		} else {
+			return nil, fmt.Errorf("expected flag %q to be int but got %T", config.StakingPortKey, p2pPortIntf)
+		}
 	}
 
 	// Parse this node's ID


### PR DESCRIPTION
## Background

I was working on setting up **Avalanche Network Runner**, and got through `indepth` example. Custom API port works fine for 5 default nodes (whose config files are present) but when we add another node in the network, `network.go` ignore API Port flag (in `addNode()` function). It only checks for API port from config file.

Here in this [line](https://github.com/ava-labs/avalanche-network-runner/blob/813da3d67099f5f9683704531257d2435e982adb/local/network.go#L412) we are checking `config.HTTPPortKey` only from `configFile`. But we are ignoring it, if it’s coming as a flag from `nodeConfig`. This can be solved if we can also check flags, like

```go
    if apiPortIntf, ok := nodeConfig.Flags[config.HTTPPortKey]; ok {
```

The flag value is being read indeed [here](https://github.com/ava-labs/avalanche-network-runner/blob/813da3d67099f5f9683704531257d2435e982adb/local/network.go#L455), and so it should print as well. But it’s not being used while assigning API port.

## Solution

Once the flags are being fetched with keys and values, we will check again, if there is any API or P2P port flag coming from `nodeConfig`. If it's there, then we can append the updated port flags.

PS - Please let me know about the specific naming conventions you are using. I have tried to keep it similar to other parts of the code.
