### PR TITLE
Add support for specifying network root directory

### DIFF
--- a/local/network.go
+++ b/local/network.go
@@ -384,7 +384,11 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 	// TODO should we do this for other directories? Profiles?
 	nodeRootDir := filepath.Join(ln.rootDir, nodeConfig.Name)
 	if err := os.Mkdir(nodeRootDir, 0o755); err != nil {
-		return nil, fmt.Errorf("error creating temp dir: %w", err)
+		if os.IsExist(err) {
+			ln.log.Warn("node root directory %s already exists", nodeRootDir)
+		} else {
+			return nil, fmt.Errorf("error creating temp dir: %w", err)
+		}
 	}
 
 	// If config file is given, don't overwrite API port, P2P port, DB path, logs path


### PR DESCRIPTION
By default the avalanche network runner creates temporary directories that are not accessible/visible to the caller. This makes it hard to pre-populate configuration (such as chain config) for custom VMs. This PR introduces the ability to pass in a root directory for the network and also ensures nodes can still start up even if the directory already exists.