### PR TITLE
[examples/local/fivenodenetwork] Fix issue about when goPath is blank

### DIFF
--- a/examples/local/fivenodenetwork/main.go
+++ b/examples/local/fivenodenetwork/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"go/build"
 	"os"
 	"os/signal"
 	"syscall"
@@ -55,6 +56,9 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+	if goPath == "" {
+		goPath = build.Default.GOPATH
 	}
 	binaryPath := fmt.Sprintf("%s%s", goPath, "/src/github.com/ava-labs/avalanchego/build/avalanchego")
 	if err := run(log, binaryPath); err != nil {


### PR DESCRIPTION
Issues: #100  #101

I debugged the variable `goPath` and it was blank.

Then I found another way of getting the `GOPATH`. The solution is from https://stackoverflow.com/a/32650077/9192954.