### PR TITLE
Fix health call race condition while installing vms

### DIFF
--- a/local/network.go
+++ b/local/network.go
@@ -436,9 +436,6 @@ func (ln *localNetwork) addNode(nodeConfig node.Config) (node.Node, error) {
 
 // See network.Network
 func (ln *localNetwork) Healthy(ctx context.Context) chan error {
-	ln.lock.RLock()
-	defer ln.lock.RUnlock()
-
 	zap.L().Info("checking local network healthiness", zap.Int("nodes", len(ln.nodes)))
 	healthyChan := make(chan error, 1)
 
@@ -448,11 +445,15 @@ func (ln *localNetwork) Healthy(ctx context.Context) chan error {
 		return healthyChan
 	}
 
-	nodes := make([]*localNode, 0, len(ln.nodes))
-	for _, node := range ln.nodes {
-		nodes = append(nodes, node)
-	}
 	go func() {
+		ln.lock.RLock()
+		defer ln.lock.RUnlock()
+
+		nodes := make([]*localNode, 0, len(ln.nodes))
+		for _, node := range ln.nodes {
+			nodes = append(nodes, node)
+		}
+
 		errGr, cctx := errgroup.WithContext(ctx)
 		for _, node := range nodes {
 			node := node

--- a/local/network.go
+++ b/local/network.go
@@ -446,6 +446,8 @@ func (ln *localNetwork) Healthy(ctx context.Context) chan error {
 	}
 
 	go func() {
+		// TODO: This will block the network for the duration of the health call.
+		// Maybe a better solution can be found.
 		ln.lock.RLock()
 		defer ln.lock.RUnlock()
 

--- a/local/network.go
+++ b/local/network.go
@@ -449,13 +449,8 @@ func (ln *localNetwork) Healthy(ctx context.Context) chan error {
 		ln.lock.RLock()
 		defer ln.lock.RUnlock()
 
-		nodes := make([]*localNode, 0, len(ln.nodes))
-		for _, node := range ln.nodes {
-			nodes = append(nodes, node)
-		}
-
 		errGr, cctx := errgroup.WithContext(ctx)
-		for _, node := range nodes {
+		for _, node := range ln.nodes {
 			node := node
 			errGr.Go(func() error {
 				// Every constants.HealthCheckInterval, query node for health status.


### PR DESCRIPTION
Proposal to fix possible race condition when the network is restarting nodes during a custom VM install and at the same time call `Health` via gRPC.

To be questioned! Might be a symptom rather than the cause.