### PR TITLE
Make healthy block

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,16 +655,10 @@ The network runner allows users to interact with an AvalancheGo network using th
 ```go
 // Network is an abstraction of an Avalanche network
 type Network interface {
-  // Returns a chan that is closed when
-  // all the nodes in the network are healthy.
-  // If an error is sent on this channel, at least 1
-  // node didn't become healthy before the timeout.
-  // If an error isn't sent on the channel before it
-  // closes, all the nodes are healthy.
+  // Returns true if all the nodes in the network are healthy.
   // A stopped network is considered unhealthy.
   // Timeout is given by the context parameter.
-  // [ctx] must eventually be cancelled -- if it isn't, a goroutine is leaked.
-  Healthy(context.Context) chan error
+  Healthy(context.Context) error
   // Stop all the nodes.
   // Returns ErrStopped if Stop() was previously called.
   Stop(context.Context) error

--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ The network runner allows users to interact with an AvalancheGo network using th
 ```go
 // Network is an abstraction of an Avalanche network
 type Network interface {
-  // Returns true if all the nodes in the network are healthy.
+  // Returns nil if all the nodes in the network are healthy.
   // A stopped network is considered unhealthy.
   // Timeout is given by the context parameter.
   Healthy(context.Context) error

--- a/examples/local/fivenodenetwork/main.go
+++ b/examples/local/fivenodenetwork/main.go
@@ -86,9 +86,8 @@ func run(log logging.Logger, binaryPath string) error {
 	// Wait until the nodes in the network are ready
 	ctx, cancel := context.WithTimeout(context.Background(), healthyTimeout)
 	defer cancel()
-	healthyChan := nw.Healthy(ctx)
 	log.Info("waiting for all nodes to report healthy...")
-	if err := <-healthyChan; err != nil {
+	if err := nw.Healthy(ctx); err != nil {
 		return err
 	}
 

--- a/examples/local/indepth/main.go
+++ b/examples/local/indepth/main.go
@@ -90,10 +90,10 @@ func run(log logging.Logger, binaryPath string) error {
 	// Wait until the nodes in the network are ready
 	ctx, cancel := context.WithTimeout(context.Background(), healthyTimeout)
 	defer cancel()
-	healthyChan := nw.Healthy(ctx)
 	log.Info("waiting for all nodes to report healthy...")
-	if err := <-healthyChan; err != nil {
+	if err := nw.Healthy(ctx); err != nil {
 		return err
+
 	}
 
 	// Print the node names
@@ -147,9 +147,8 @@ func run(log logging.Logger, binaryPath string) error {
 	// Wait until the nodes in the updated network are ready
 	ctx, cancel = context.WithTimeout(context.Background(), healthyTimeout)
 	defer cancel()
-	healthyChan = nw.Healthy(ctx)
 	log.Info("waiting for updated network to report healthy...")
-	if err := <-healthyChan; err != nil {
+	if err := nw.Healthy(ctx); err != nil {
 		return err
 	}
 

--- a/local/network.go
+++ b/local/network.go
@@ -472,20 +472,20 @@ func (ln *localNetwork) Healthy(ctx context.Context) error {
 		}
 	}()
 
-	errGr, cctx := errgroup.WithContext(ctx)
+	errGr, ctx := errgroup.WithContext(ctx)
 	for _, node := range ln.nodes {
 		node := node
 		errGr.Go(func() error {
 			// Every [healthCheckFreq], query node for health status.
 			// Do this until ctx timeout or network closed.
 			for {
-				health, err := node.client.HealthAPI().Health(cctx)
+				health, err := node.client.HealthAPI().Health(ctx)
 				if err == nil && health.Healthy {
 					ln.log.Debug("node %q became healthy", node.name)
 					return nil
 				}
 				select {
-				case <-cctx.Done():
+				case <-ctx.Done():
 					return fmt.Errorf("node %q failed to become healthy within timeout", node.GetName())
 				case <-time.After(healthCheckFreq):
 				}

--- a/local/network.go
+++ b/local/network.go
@@ -462,7 +462,7 @@ func (ln *localNetwork) Healthy(ctx context.Context) error {
 	// so that we calls to Healthy() below immediately return.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go func() {
+	go func(ctx context.Context) {
 		// This goroutine runs until [ln.Stop] is called
 		// or this function returns.
 		select {
@@ -470,7 +470,7 @@ func (ln *localNetwork) Healthy(ctx context.Context) error {
 			cancel()
 		case <-ctx.Done():
 		}
-	}()
+	}(ctx)
 
 	errGr, ctx := errgroup.WithContext(ctx)
 	for _, node := range ln.nodes {
@@ -547,7 +547,7 @@ func (ln *localNetwork) GetAllNodes() (map[string]node.Node, error) {
 }
 
 func (ln *localNetwork) Stop(ctx context.Context) error {
-	var err error
+	err := network.ErrStopped
 	ln.stopOnce.Do(
 		func() {
 			ln.onStopCtxCancel()

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -1256,8 +1256,8 @@ func TestHealthyDuringNetworkStop(t *testing.T) {
 	go func() {
 		healthyChan <- net.Healthy(context.Background())
 	}()
-	// Sleep to make sure that the health API call is actually in progress
-	time.Sleep(healthCheckFreq + 500*time.Millisecond)
+	// Wait to make sure we're actually blocking on Health API call
+	time.Sleep(500 * time.Millisecond)
 	err = net.Stop(context.Background())
 	assert.NoError(err)
 	select {

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -1256,6 +1256,8 @@ func TestHealthyDuringNetworkStop(t *testing.T) {
 	go func() {
 		healthyChan <- net.Healthy(context.Background())
 	}()
+	// Sleep to make sure that the health API call is actually in progress
+	time.Sleep(healthCheckFreq + 500*time.Millisecond)
 	err = net.Stop(context.Background())
 	assert.NoError(err)
 	select {

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -643,19 +643,19 @@ func TestStoppedNetwork(t *testing.T) {
 	assert.EqualValues(net.Stop(context.Background()), network.ErrStopped)
 	// AddNode failure
 	_, err = net.AddNode(networkConfig.NodeConfigs[1])
-	assert.EqualValues(err, network.ErrStopped)
+	assert.EqualValues(network.ErrStopped, err)
 	// GetNode failure
 	_, err = net.GetNode(networkConfig.NodeConfigs[0].Name)
 	assert.EqualValues(err, network.ErrStopped)
 	// second GetNodeNames should return no nodes
 	_, err = net.GetNodeNames()
-	assert.EqualValues(err, network.ErrStopped)
+	assert.EqualValues(network.ErrStopped, err)
 	// RemoveNode failure
-	assert.EqualValues(net.RemoveNode(networkConfig.NodeConfigs[0].Name), network.ErrStopped)
+	assert.EqualValues(network.ErrStopped, net.RemoveNode(networkConfig.NodeConfigs[0].Name))
 	// Healthy failure
 	assert.EqualValues(awaitNetworkHealthy(net, defaultHealthyTimeout), network.ErrStopped)
 	_, err = net.GetAllNodes()
-	assert.EqualValues(network.ErrStopped, err)
+	assert.EqualValues(err, network.ErrStopped)
 }
 
 func TestGetAllNodes(t *testing.T) {

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -906,8 +906,7 @@ func testNetworkConfig(t *testing.T) network.Config {
 func awaitNetworkHealthy(net network.Network, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	healthyCh := net.Healthy(ctx)
-	return <-healthyCh
+	return net.Healthy(ctx)
 }
 
 func TestAddNetworkFlags(t *testing.T) {

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -1263,7 +1263,9 @@ func TestHealthyDuringNetworkStop(t *testing.T) {
 	select {
 	case err := <-healthyChan:
 		assert.Error(err)
-	case <-time.After(3 * time.Second):
+	case <-time.After(1 * time.Second):
+		// Since [net.Stop] was called, [net.Healthy] should immediately return.
+		// We assume that it will do so within 1 second.
 		assert.Fail("Healthy should've returned immediately because network closed")
 	}
 }

--- a/local/node_test.go
+++ b/local/node_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/network/peer"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/utils"
-	avago_utils "github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/version"
@@ -66,7 +65,7 @@ func verifyProtocol(
 	// send the peer our version and peerlist
 
 	// create the version message
-	myIP := avago_utils.IPDesc{
+	myIP := utils.IPDesc{
 		IP:   net.IPv6zero,
 		Port: 0,
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -11,7 +11,7 @@ var ErrStopped = errors.New("network stopped")
 
 // Network is an abstraction of an Avalanche network
 type Network interface {
-	// Returns true if all the nodes in the network are healthy.
+	// Returns nil if all the nodes in the network are healthy.
 	// A stopped network is considered unhealthy.
 	// Timeout is given by the context parameter.
 	Healthy(context.Context) error

--- a/network/network.go
+++ b/network/network.go
@@ -11,15 +11,10 @@ var ErrStopped = errors.New("network stopped")
 
 // Network is an abstraction of an Avalanche network
 type Network interface {
-	// Returns a chan that is closed when
-	// all the nodes in the network are healthy.
-	// If an error is sent on this channel, at least 1
-	// node didn't become healthy before the timeout.
-	// If an error isn't sent on the channel before it
-	// closes, all the nodes are healthy.
+	// Returns true if all the nodes in the network are healthy.
 	// A stopped network is considered unhealthy.
 	// Timeout is given by the context parameter.
-	Healthy(context.Context) chan error
+	Healthy(context.Context) error
 	// Stop all the nodes.
 	// Returns ErrStopped if Stop() was previously called.
 	Stop(context.Context) error

--- a/server/custom_vms.go
+++ b/server/custom_vms.go
@@ -91,17 +91,7 @@ func (lc *localNetwork) waitForCustomVMsReady(ctx context.Context) error {
 	println()
 	color.Outf("{{blue}}{{bold}}waiting for custom VMs to report healthy...{{/}}\n")
 
-	healthyCtx, healthyCtxCancel := context.WithCancel(ctx)
-	defer healthyCtxCancel()
-	go func() {
-		select {
-		case <-lc.stopc:
-			healthyCtxCancel()
-		case <-healthyCtx.Done():
-		}
-	}()
-
-	if err := lc.nw.Healthy(healthyCtx); err != nil {
+	if err := lc.nw.Healthy(ctx); err != nil {
 		return err
 	}
 

--- a/server/network.go
+++ b/server/network.go
@@ -284,17 +284,7 @@ var errAborted = errors.New("aborted")
 func (lc *localNetwork) waitForLocalClusterReady(ctx context.Context) error {
 	color.Outf("{{blue}}{{bold}}waiting for all nodes to report healthy...{{/}}\n")
 
-	healthyCtx, healthyCtxCancel := context.WithCancel(ctx)
-	defer healthyCtxCancel()
-	go func() {
-		select {
-		case <-lc.stopc:
-			healthyCtxCancel()
-		case <-healthyCtx.Done():
-		}
-	}()
-
-	if err := lc.nw.Healthy(healthyCtx); err != nil {
+	if err := lc.nw.Healthy(ctx); err != nil {
 		return err
 	}
 

--- a/server/network.go
+++ b/server/network.go
@@ -284,16 +284,18 @@ var errAborted = errors.New("aborted")
 func (lc *localNetwork) waitForLocalClusterReady(ctx context.Context) error {
 	color.Outf("{{blue}}{{bold}}waiting for all nodes to report healthy...{{/}}\n")
 
-	hc := lc.nw.Healthy(ctx)
-	select {
-	case <-lc.stopc:
-		return errAborted
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-hc:
-		if err != nil {
-			return err
+	healthyCtx, healthyCtxCancel := context.WithCancel(ctx)
+	defer healthyCtxCancel()
+	go func() {
+		select {
+		case <-lc.stopc:
+			healthyCtxCancel()
+		case <-healthyCtx.Done():
 		}
+	}()
+
+	if err := lc.nw.Healthy(healthyCtx); err != nil {
+		return err
 	}
 
 	nodes, err := lc.nw.GetAllNodes()


### PR DESCRIPTION
* Make `network.Healthy` block and return `error` rather than `chan error`
* Make it so that if `network.Stop` is called while a call to `network.Healthy` is ongoing, `network.Healthy` immediately returns an error