### PR TITLE
Cancellable start context

### DIFF
--- a/server/network.go
+++ b/server/network.go
@@ -70,9 +70,10 @@ type localNetwork struct {
 	customVMsReadyChCloseOnce sync.Once
 	customVMRestartMu         *sync.RWMutex
 
-	stopCh      chan struct{}
-	startDoneCh chan struct{}
-	startErrCh  chan error
+	stopCh         chan struct{}
+	startDoneCh    chan struct{}
+	startErrCh     chan error
+	startCtxCancel context.CancelFunc // allow the Start context to be cancelled
 
 	stopOnce sync.Once
 }
@@ -250,10 +251,16 @@ func createConfigFileString(configFileMap map[string]interface{}, logDir string,
 	return string(finalJSON), nil
 }
 
-func (lc *localNetwork) start(ctx context.Context) {
+func (lc *localNetwork) start(argCtx context.Context) {
 	defer func() {
 		close(lc.startDoneCh)
 	}()
+
+	// start triggers a series of different time consuming actions
+	// (in case of subnets: create a wallet, create subnets, issue txs, etc.)
+	// We may need to cancel the context, for example if the client hits Ctrl-C
+	var ctx context.Context
+	ctx, lc.startCtxCancel = context.WithCancel(argCtx)
 
 	color.Outf("{{blue}}{{bold}}create and run local network{{/}}\n")
 	nw, err := local.NewNetwork(lc.logger, lc.cfg, lc.options.rootDataDir, lc.options.snapshotsDir)
@@ -420,6 +427,10 @@ func (lc *localNetwork) updateNodeInfo() error {
 func (lc *localNetwork) stop(ctx context.Context) {
 	lc.stopOnce.Do(func() {
 		close(lc.stopCh)
+		// cancel possible concurrent still running start
+		if lc.startCtxCancel != nil {
+			lc.startCtxCancel()
+		}
 		serr := lc.nw.Stop(ctx)
 		<-lc.startDoneCh
 		color.Outf("{{red}}{{bold}}terminated network{{/}} (error %v)\n", serr)

--- a/server/server.go
+++ b/server/server.go
@@ -759,10 +759,7 @@ func (s *server) RestartNode(ctx context.Context, req *rpcpb.RestartNodeRequest)
 
 func (s *server) Stop(ctx context.Context, req *rpcpb.StopRequest) (*rpcpb.StopResponse, error) {
 	zap.L().Debug("received stop request")
-	info := s.getClusterInfo()
-	if info == nil {
-		return nil, ErrNotBootstrapped
-	}
+	info := &rpcpb.ClusterInfo{}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -773,9 +770,9 @@ func (s *server) Stop(ctx context.Context, req *rpcpb.StopRequest) (*rpcpb.StopR
 	}
 	s.network.stop(ctx)
 	s.network = nil
-	info.Healthy = false
 	s.clusterInfo = nil
 
+	info.Healthy = false
 	return &rpcpb.StopResponse{ClusterInfo: info}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -52,10 +52,10 @@ type Server interface {
 type server struct {
 	cfg Config
 
-	rootCtx    context.Context
-	cancelFunc context.CancelFunc // allow the Start context to be cancelled
-	closeOnce  sync.Once
-	closed     chan struct{}
+	rootCtx        context.Context
+	startCtxCancel context.CancelFunc // allow the Start context to be cancelled
+	closeOnce      sync.Once
+	closed         chan struct{}
 
 	ln               net.Listener
 	gRPCServer       *grpc.Server
@@ -189,7 +189,6 @@ func (s *server) Run(rootCtx context.Context) (err error) {
 		zap.L().Warn("gRPC server failed", zap.Error(err))
 		if !s.cfg.GwDisabled {
 			zap.L().Warn("closed gRPC gateway server", zap.Error(s.gwServer.Close()))
-			zap.L().Warn("closed gRPC gateway server", zap.Error(s.gwServer.Close()))
 			<-gwErrc
 		}
 
@@ -205,7 +204,7 @@ func (s *server) Run(rootCtx context.Context) (err error) {
 		defer stopCtxCancel()
 		// we need to cancel the Start context so that any pending action with that context
 		// can be cancelled
-		s.cancelFunc()
+		s.startCtxCancel()
 		s.network.stop(stopCtx)
 		zap.L().Warn("network stopped")
 	}
@@ -363,11 +362,11 @@ func (s *server) Start(ctx context.Context, req *rpcpb.StartRequest) (*rpcpb.Sta
 	// start triggers a series of different time consuming actions
 	// (in case of subnets: create a wallet, create subnets, issue txs, etc.)
 	// We may need to cancel the context, for example if the client hits Ctrl-C
-	var cancellableCtx context.Context
-	cancellableCtx, s.cancelFunc = context.WithCancel(ctx)
+	var startCtx context.Context
+	startCtx, s.startCtxCancel = context.WithCancel(ctx)
 	// start non-blocking to install local cluster + custom VMs (if applicable)
 	// the user is expected to poll cluster status
-	go s.network.start(cancellableCtx)
+	go s.network.start(startCtx)
 
 	// update cluster info non-blocking
 	// the user is expected to poll this latest information
@@ -768,6 +767,10 @@ func (s *server) Stop(ctx context.Context, req *rpcpb.StopRequest) (*rpcpb.StopR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// cancel possible concurrent still running start
+	if s.startCtxCancel != nil {
+		s.startCtxCancel()
+	}
 	s.network.stop(ctx)
 	s.network = nil
 	info.Healthy = false

--- a/server/server.go
+++ b/server/server.go
@@ -750,17 +750,18 @@ func (s *server) RestartNode(ctx context.Context, req *rpcpb.RestartNodeRequest)
 
 func (s *server) Stop(ctx context.Context, req *rpcpb.StopRequest) (*rpcpb.StopResponse, error) {
 	zap.L().Debug("received stop request")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.network == nil {
 		return nil, ErrNotBootstrapped
 	}
 
-	info := s.getClusterInfo()
+	info := s.clusterInfo
 	if info == nil {
 		info = &rpcpb.ClusterInfo{}
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.network.stop(ctx)
 	s.network = nil


### PR DESCRIPTION
Currently the Start context can not be cancelled.
This is required though if for example a client application hits Ctrl-C and wants to clean up immediately