### PR TITLE
Custom VMs validators

### DIFF
--- a/local/network.go
+++ b/local/network.go
@@ -122,7 +122,19 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+    var genesisMap map[string]interface{}
+    if err = json.Unmarshal(genesis, &genesisMap); err != nil {
+		panic(err)
+    }
+    fmt.Println(genesisMap)
+    fmt.Println(genesisMap["startTime"].(float64))
+    fmt.Println(genesisMap["allocations"].([]interface{})[0].(map[string]interface{})["unlockSchedule"].([]interface{})[0].(map[string]interface{})["locktime"].(float64))
+    os.Exit(1)
+
 	defaultNetworkConfig.Genesis = string(genesis)
+
+    // update genesis so as to start validating in the present
 
 	for i := 0; i < len(defaultNetworkConfig.NodeConfigs); i++ {
 		configFile, err := fs.ReadFile(configsDir, fmt.Sprintf("node%d/config.json", i))

--- a/server/custom_vms.go
+++ b/server/custom_vms.go
@@ -110,7 +110,7 @@ func (lc *localNetwork) installCustomVMs(
 		}
 	}
 
-	subnetIDs := make([]ids.ID, len(chainSpecs))
+	subnetIDs := []ids.ID{}
 	for _, chainSpec := range chainSpecs {
 		subnetID, err := ids.FromString(*chainSpec.subnetId)
 		if err != nil {
@@ -518,16 +518,16 @@ func addSubnetValidators(
 		if err != nil {
 			return err
 		}
-		curValidators := make(map[ids.NodeID]struct{})
+		subnetValidators := make(map[ids.NodeID]struct{})
 		for _, v := range vs {
-			curValidators[v.NodeID] = struct{}{}
+			subnetValidators[v.NodeID] = struct{}{}
 		}
 		for nodeName, nodeInfo := range nodeInfos {
 			nodeID, err := ids.NodeIDFromString(nodeInfo.Id)
 			if err != nil {
 				return err
 			}
-			_, isValidator := curValidators[nodeID]
+			_, isValidator := subnetValidators[nodeID]
 			if !isValidator {
 				cctx, cancel := createDefaultCtx(ctx)
 				txID, err := baseWallet.P().IssueAddSubnetValidatorTx(

--- a/server/custom_vms.go
+++ b/server/custom_vms.go
@@ -197,6 +197,10 @@ func (lc *localNetwork) setupWalletAndInstallSubnets(
 		return nil, err
 	}
 
+	if err = waitSubnetValidators(ctx, lc.nodeInfos, platformCli, subnetIDs, lc.stopCh); err != nil {
+		return nil, err
+	}
+
 	println()
 	color.Outf("{{green}}checking the remaining balance of the base wallet{{/}}\n")
 	balances, err := baseWallet.P().Builder().GetBalance()

--- a/server/custom_vms.go
+++ b/server/custom_vms.go
@@ -355,7 +355,7 @@ func addPrimaryValidators(
 		txID, err := baseWallet.P().IssueAddValidatorTx(
 			&validator.Validator{
 				NodeID: nodeID,
-				Start:  uint64(time.Now().Add(10 * time.Second).Unix()),
+				Start:  uint64(time.Now().Add(20 * time.Second).Unix()),
 				End:    uint64(time.Now().Add(validationDuration).Unix()),
 				Wght:   1 * units.Avax,
 			},


### PR DESCRIPTION
- update genesis for default config to start validation at network creation time
- set primary/subnet validator start time as quick as posible
- set primary validator end time (when renewing validation) as large as posible
- set subnet validator end time (when renewing validation) to equal primary validator end time
- add renew of primary/subnet validators for blockchain creation. misc bug fix.
- add wait for subnet validators to start, when waiting for custom vms or subnet creation