### PR TITLE
Call updateNodeInfo after adding new node

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -777,6 +777,10 @@ func (s *server) AddNode(ctx context.Context, req *rpcpb.AddNodeRequest) (*rpcpb
 	if err != nil {
 		return nil, err
 	}
+	if err := s.network.updateNodeInfo(); err != nil {
+		return nil, err
+	}
+
 
 	return &rpcpb.AddNodeResponse{ClusterInfo: s.clusterInfo}, nil
 }


### PR DESCRIPTION
Currently, after adding a new node, `/control/health` does not show the added node. This should fix that.