### PR TITLE
README: add an example with global node config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Additional optional parameters which can be passed to the start command:
 	--custom-node-configs" '{"node1":{"log-level":"debug","api-admin-enabled":false},"node2":{...},...}'
 ```
 
+For example, to set `avalanchego --http-host` flag for all nodes:
+
+```bash
+# to expose local RPC server to all traffic
+# (e.g., run network runner within cloud instance)
+curl -X POST -k http://localhost:8081/v1/control/start -d '{"execPath":"'${AVALANCHEGO_EXEC_PATH}'","globalNodeConfig":"{\"http-host\":\"0.0.0.0\"}",...}'
+
+# or
+avalanche-network-runner control start \
+--global-node-config '{"http-host":"0.0.0.0"}'
+```
+
 `--plugin-dir` and `--custom-vms` are parameters relevant to subnet operation.
 See the [subnet](#network-runner-rpc-server-subnet-evm-example) section for details about how to run subnets.
 


### PR DESCRIPTION
```
avalanche-network-runner server \
--log-level debug \
--port=":8080" \
--grpc-gateway-port=":8081"
```

> `curl -X POST -k http://localhost:8081/v1/control/start -d '{"execPath":"'${AVALANCHEGO_EXEC_PATH}'","globalNodeConfig":"{\"http-host\":\"0.0.0.0\"}","numNodes":5,"logLevel":"INFO","pluginDir":"'${AVALANCHEGO_PLUGIN_PATH}'","customVms":{"subnetevm":"/tmp/subnet-evm.genesis.json"}}'`


<img width="1106" alt="Screen Shot 2022-07-08 at 5 42 22 PM" src="https://user-images.githubusercontent.com/6799218/177964907-4586a418-bc75-4166-a0d9-6fd01882df71.png">


> `{"level":"info","ts":"2022-07-08T17:34:02.463+0800","caller":"server/server.go:315","msg":"starting","execPath":"/Users/leegyuho/go/src/github.com/ava-labs/avalanchego/build/avalanchego","numNodes":5,"whitelistedSubnets":"","pid":8114,"rootDataDir":"/var/folders/xt/szh_n5x154x2hyhj0zkpd3qr0000gn/T/network-runner-root-data_20220708_173402","pluginDir":"/Users/leegyuho/go/src/github.com/ava-labs/avalanchego/build/plugins","chainConfigs":null,"defaultNodeConfig":"{\"http-host\":\"0.0.0.0\"}"}`

Signed-off-by: Gyuho Lee <gyuho.lee@avalabs.org>