### PR TITLE
fix goreleaser issue

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          path: avalanche-network-runner
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -92,6 +93,7 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
+          workdir: ./avalanche-network-runner/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -79,6 +79,7 @@ jobs:
           path: osxcross
       - name: Build osxcross
         run: |
+          sudo apt-get -y install clang llvm-dev libxml2-dev uuid-dev libssl-dev bash patch make tar xz-utils bzip2 gzip sed cpio libbz2-dev
           cd osxcross
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/$MACOS_SDK_FNAME -O tarballs/$MACOS_SDK_FNAME
           echo $MACOS_SDK_CHECKSUM tarballs/$MACOS_SDK_FNAME | sha256sum -c -


### PR DESCRIPTION
Goreleaser failing on real releases. there is a check for the git repositoty to not being dirty, and  that seems to only be checked when doing the release, not when doing snapshots. That's why it was not seen before.
The repo was dirty because osxcross was inside it. this PR sets osxcross and avalanche-network-runner side by side.