### PR TITLE
Fix exit status for E2E

### DIFF
--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -166,7 +166,11 @@ echo "running e2e tests"
 --grpc-gateway-endpoint="0.0.0.0:8081" \
 --avalanchego-path-1=/tmp/avalanchego-v${VERSION_1}/avalanchego \
 --avalanchego-path-2=/tmp/avalanchego-v${VERSION_2}/avalanchego \
---subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm || (kill ${PID}; exit)
+--subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm
+EXIT_CODE=$? # to fail the script if ginkgo failed
 
 kill ${PID}
-echo "ALL SUCCESS!"
+if [[ ${EXIT_CODE} == 0 ]]; then
+  echo "ALL SUCCESS!"
+fi
+exit ${EXIT_CODE}

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -158,6 +158,13 @@ server \
 #--disable-nodes-output \
 PID=${!}
 
+function cleanup()
+{
+  echo "shutting down network runner"
+  kill ${PID}
+}
+trap cleanup EXIT
+
 echo "running e2e tests"
 ./tests/e2e/e2e.test \
 --ginkgo.v \
@@ -167,14 +174,4 @@ echo "running e2e tests"
 --grpc-gateway-endpoint="0.0.0.0:8081" \
 --avalanchego-path-1=/tmp/avalanchego-v${VERSION_1}/avalanchego \
 --avalanchego-path-2=/tmp/avalanchego-v${VERSION_2}/avalanchego \
---subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm || EXIT_CODE=$?
-
-echo "shutting down network runner"
-kill ${PID}
-
-if [[ ${EXIT_CODE} == 0 ]]; then
-  echo "SUCCESS!"
-else
-  echo "FAILURE!"
-fi
-exit ${EXIT_CODE}
+--subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -146,7 +146,7 @@ ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 snapshots_dir=/tmp/avalanche-network-runner-snapshots-e2e/
 rm -rf $snapshots_dir
 
-killall network.runner || echo
+killall avalanche-network-runner || true
 
 echo "launch local test cluster in the background"
 bin/avalanche-network-runner \
@@ -167,11 +167,14 @@ echo "running e2e tests"
 --grpc-gateway-endpoint="0.0.0.0:8081" \
 --avalanchego-path-1=/tmp/avalanchego-v${VERSION_1}/avalanchego \
 --avalanchego-path-2=/tmp/avalanchego-v${VERSION_2}/avalanchego \
---subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm
-EXIT_CODE=$? # to fail the script if ginkgo failed
+--subnet-evm-path=/tmp/subnet-evm-v${SUBNET_EVM_VERSION}/subnet-evm || EXIT_CODE=$?
 
+echo "shutting down network runner"
 kill ${PID}
+
 if [[ ${EXIT_CODE} == 0 ]]; then
-  echo "ALL SUCCESS!"
+  echo "SUCCESS!"
+else
+  echo "FAILURE!"
 fi
 exit ${EXIT_CODE}

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -161,6 +161,7 @@ PID=${!}
 echo "running e2e tests"
 ./tests/e2e/e2e.test \
 --ginkgo.v \
+--ginkgo.fail-fast \
 --log-level debug \
 --grpc-endpoint="0.0.0.0:8080" \
 --grpc-gateway-endpoint="0.0.0.0:8081" \


### PR DESCRIPTION
I previously did something similar to fix `subnet-evm`: https://github.com/ava-labs/subnet-evm/blob/0fb0afe8a38daf13880e8d3c0fc43b4edc74c80e/scripts/run.sh#L241-L242