### PR TITLE
server: fix error message format

### DIFF
--- a/server/network.go
+++ b/server/network.go
@@ -479,7 +479,11 @@ func (lc *localNetwork) Stop(ctx context.Context) {
 
 		if lc.nw != nil {
 			err := lc.nw.Stop(ctx)
-			ux.Print(lc.log, logging.Red.Wrap("terminated network %s"), err)
+			msg := "terminated network"
+			if err != nil {
+				msg += fmt.Sprintf(" (error %v)", err)
+			}
+			ux.Print(lc.log, logging.Red.Wrap(msg))
 		}
 	})
 }


### PR DESCRIPTION
Fix

```
terminated network %!s(<nil>)
[03-13|01:39:41.080] INFO ux/output.go:14 terminated network %!s(<nil>)
```