### PR TITLE
Respect value of RedirectStdout/RedirectStderr

### DIFF
--- a/examples/local/fivenodenetwork/main.go
+++ b/examples/local/fivenodenetwork/main.go
@@ -68,7 +68,7 @@ func main() {
 
 func run(log logging.Logger, binaryPath string) error {
 	// Create the network
-	nw, err := local.NewDefaultNetwork(log, binaryPath, true)
+	nw, err := local.NewDefaultNetwork(log, binaryPath, true, true, true)
 	if err != nil {
 		return err
 	}

--- a/examples/local/indepth/main.go
+++ b/examples/local/indepth/main.go
@@ -73,7 +73,7 @@ func main() {
 
 func run(log logging.Logger, binaryPath string) error {
 	// Create the network
-	nw, err := local.NewDefaultNetwork(log, binaryPath, true)
+	nw, err := local.NewDefaultNetwork(log, binaryPath, true, true, true)
 	if err != nil {
 		return err
 	}

--- a/local/blockchain.go
+++ b/local/blockchain.go
@@ -292,7 +292,11 @@ func (ln *localNetwork) installCustomChains(
 			_, ok := ln.nodes[nodeName]
 			if !ok {
 				ln.log.Info(logging.Green.Wrap(fmt.Sprintf("adding new participant %s", nodeName)))
-				if _, err := ln.addNode(node.Config{Name: nodeName, RedirectStdout: true, RedirectStderr: true}); err != nil {
+				if _, err := ln.addNode(node.Config{
+					Name:           nodeName,
+					RedirectStdout: ln.redirectStdout,
+					RedirectStderr: ln.redirectStderr,
+				}); err != nil {
 					return nil, err
 				}
 			}
@@ -437,7 +441,11 @@ func (ln *localNetwork) installSubnets(
 			_, ok := ln.nodes[nodeName]
 			if !ok {
 				ln.log.Info(logging.Green.Wrap(fmt.Sprintf("adding new participant %s", nodeName)))
-				if _, err := ln.addNode(node.Config{Name: nodeName}); err != nil {
+				if _, err := ln.addNode(node.Config{
+					Name:           nodeName,
+					RedirectStdout: ln.redirectStdout,
+					RedirectStderr: ln.redirectStderr,
+				}); err != nil {
 					return nil, err
 				}
 			}
@@ -1065,7 +1073,11 @@ func (ln *localNetwork) addPermissionlessValidators(
 		_, ok := ln.nodes[validatorSpec.NodeName]
 		if !ok {
 			ln.log.Info(logging.Green.Wrap(fmt.Sprintf("adding new participant %s", validatorSpec.NodeName)))
-			if _, err := ln.addNode(node.Config{Name: validatorSpec.NodeName}); err != nil {
+			if _, err := ln.addNode(node.Config{
+				Name:           validatorSpec.NodeName,
+				RedirectStdout: ln.redirectStdout,
+				RedirectStderr: ln.redirectStderr,
+			}); err != nil {
 				return err
 			}
 		}

--- a/local/blockchain.go
+++ b/local/blockchain.go
@@ -292,7 +292,7 @@ func (ln *localNetwork) installCustomChains(
 			_, ok := ln.nodes[nodeName]
 			if !ok {
 				ln.log.Info(logging.Green.Wrap(fmt.Sprintf("adding new participant %s", nodeName)))
-				if _, err := ln.addNode(node.Config{Name: nodeName}); err != nil {
+				if _, err := ln.addNode(node.Config{Name: nodeName, RedirectStdout: true, RedirectStderr: true}); err != nil {
 					return nil, err
 				}
 			}

--- a/local/network.go
+++ b/local/network.go
@@ -115,6 +115,8 @@ type localNetwork struct {
 	subnetConfigFiles map[string]string
 	// if true, for ports given in conf that are already taken, assign new random ones
 	reassignPortsIfUsed bool
+	redirectStdout      bool
+	redirectStderr      bool
 	// map from subnet id to elastic subnet tx id
 	subnetID2ElasticSubnetID map[ids.ID]ids.ID
 }
@@ -265,6 +267,8 @@ func NewNetwork(
 	rootDir string,
 	snapshotsDir string,
 	reassignPortsIfUsed bool,
+	redirectStdout bool,
+	redirectStderr bool,
 ) (network.Network, error) {
 	net, err := newNetwork(
 		log,
@@ -278,6 +282,8 @@ func NewNetwork(
 		rootDir,
 		snapshotsDir,
 		reassignPortsIfUsed,
+		redirectStdout,
+		redirectStderr,
 	)
 	if err != nil {
 		return net, err
@@ -295,6 +301,8 @@ func newNetwork(
 	rootDir string,
 	snapshotsDir string,
 	reassignPortsIfUsed bool,
+	redirectStdout bool,
+	redirectStderr bool,
 ) (*localNetwork, error) {
 	var err error
 	if rootDir == "" {
@@ -329,6 +337,8 @@ func newNetwork(
 		rootDir:                  rootDir,
 		snapshotsDir:             snapshotsDir,
 		reassignPortsIfUsed:      reassignPortsIfUsed,
+		redirectStdout:           redirectStdout,
+		redirectStderr:           redirectStderr,
 		subnetID2ElasticSubnetID: map[ids.ID]ids.ID{},
 	}
 	return net, nil
@@ -357,9 +367,11 @@ func NewDefaultNetwork(
 	log logging.Logger,
 	binaryPath string,
 	reassignPortsIfUsed bool,
+	redirectStdout bool,
+	redirectStderr bool,
 ) (network.Network, error) {
 	config := NewDefaultConfig(binaryPath)
-	return NewNetwork(log, config, "", "", reassignPortsIfUsed)
+	return NewNetwork(log, config, "", "", reassignPortsIfUsed, redirectStdout, redirectStderr)
 }
 
 // NewDefaultConfig creates a new default network config

--- a/local/network.go
+++ b/local/network.go
@@ -115,8 +115,10 @@ type localNetwork struct {
 	subnetConfigFiles map[string]string
 	// if true, for ports given in conf that are already taken, assign new random ones
 	reassignPortsIfUsed bool
-	redirectStdout      bool
-	redirectStderr      bool
+	// if true, direct this node's Stdout to os.Stdout
+	redirectStdout bool
+	// if true, direct this node's Stderr to os.Stderr
+	redirectStderr bool
 	// map from subnet id to elastic subnet tx id
 	subnetID2ElasticSubnetID map[ids.ID]ids.ID
 }

--- a/local/network_test.go
+++ b/local/network_test.go
@@ -150,6 +150,8 @@ func TestNewNetworkEmpty(t *testing.T) {
 		"",
 		"",
 		false,
+		false,
+		false,
 	)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
@@ -213,6 +215,8 @@ func TestNewNetworkOneNode(t *testing.T) {
 		"",
 		"",
 		false,
+		false,
+		false,
 	)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
@@ -240,6 +244,8 @@ func TestNewNetworkFailToStartNode(t *testing.T) {
 		&localTestFailedStartProcessCreator{},
 		"",
 		"",
+		false,
+		false,
 		false,
 	)
 	require.NoError(err)
@@ -477,7 +483,7 @@ func TestWrongNetworkConfigs(t *testing.T) {
 	require := require.New(t)
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+			net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 			require.NoError(err)
 			err = net.loadConfig(context.Background(), tt.config)
 			require.Error(err)
@@ -491,7 +497,7 @@ func TestUnhealthyNetwork(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	networkConfig := testNetworkConfig(t)
-	net, err := newNetwork(logging.NoLog{}, newMockAPIUnhealthy, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPIUnhealthy, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)
@@ -506,7 +512,7 @@ func TestGeneratedNodesNames(t *testing.T) {
 	for i := range networkConfig.NodeConfigs {
 		networkConfig.NodeConfigs[i].Name = ""
 	}
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)
@@ -526,7 +532,7 @@ func TestGenerateDefaultNetwork(t *testing.T) {
 	require := require.New(t)
 	binaryPath := "pepito"
 	networkConfig := NewDefaultConfig(binaryPath)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)
@@ -576,7 +582,7 @@ func TestNetworkFromConfig(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	networkConfig := testNetworkConfig(t)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)
@@ -600,7 +606,7 @@ func TestNetworkNodeOps(t *testing.T) {
 	// Start a new, empty network
 	emptyNetworkConfig, err := emptyNetworkConfig()
 	require.NoError(err)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), emptyNetworkConfig)
 	require.NoError(err)
@@ -638,7 +644,7 @@ func TestNodeNotFound(t *testing.T) {
 	emptyNetworkConfig, err := emptyNetworkConfig()
 	require.NoError(err)
 	networkConfig := testNetworkConfig(t)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), emptyNetworkConfig)
 	require.NoError(err)
@@ -671,7 +677,7 @@ func TestStoppedNetwork(t *testing.T) {
 	emptyNetworkConfig, err := emptyNetworkConfig()
 	require.NoError(err)
 	networkConfig := testNetworkConfig(t)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), emptyNetworkConfig)
 	require.NoError(err)
@@ -704,7 +710,7 @@ func TestStoppedNetwork(t *testing.T) {
 func TestGetAllNodes(t *testing.T) {
 	require := require.New(t)
 	networkConfig := testNetworkConfig(t)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)
@@ -756,6 +762,8 @@ func TestFlags(t *testing.T) {
 		"",
 		"",
 		false,
+		false,
+		false,
 	)
 	require.NoError(err)
 	err = nw.loadConfig(context.Background(), networkConfig)
@@ -785,6 +793,8 @@ func TestFlags(t *testing.T) {
 		"",
 		"",
 		false,
+		false,
+		false,
 	)
 	require.NoError(err)
 	err = nw.loadConfig(context.Background(), networkConfig)
@@ -812,6 +822,8 @@ func TestFlags(t *testing.T) {
 		},
 		"",
 		"",
+		false,
+		false,
 		false,
 	)
 	require.NoError(err)
@@ -1269,7 +1281,7 @@ func TestRemoveBeacon(t *testing.T) {
 	// create a network with no nodes in it
 	emptyNetworkConfig, err := emptyNetworkConfig()
 	require.NoError(err)
-	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPISuccessful, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), emptyNetworkConfig)
 	require.NoError(err)
@@ -1320,7 +1332,7 @@ func TestHealthyDuringNetworkStop(t *testing.T) {
 	require := require.New(t)
 	networkConfig := testNetworkConfig(t)
 	// Calls to a node's Healthy() function blocks until context cancelled
-	net, err := newNetwork(logging.NoLog{}, newMockAPIHealthyBlocks, &localTestSuccessfulNodeProcessCreator{}, "", "", false)
+	net, err := newNetwork(logging.NoLog{}, newMockAPIHealthyBlocks, &localTestSuccessfulNodeProcessCreator{}, "", "", false, false, false)
 	require.NoError(err)
 	err = net.loadConfig(context.Background(), networkConfig)
 	require.NoError(err)

--- a/local/snapshot.go
+++ b/local/snapshot.go
@@ -70,6 +70,8 @@ func NewNetworkFromSnapshot(
 	subnetConfigs map[string]string,
 	flags map[string]interface{},
 	reassignPortsIfUsed bool,
+	redirectStdout bool,
+	redirectStderr bool,
 ) (network.Network, error) {
 	net, err := newNetwork(
 		log,
@@ -83,6 +85,8 @@ func NewNetworkFromSnapshot(
 		rootDir,
 		snapshotsDir,
 		reassignPortsIfUsed,
+		redirectStdout,
+		redirectStderr,
 	)
 	if err != nil {
 		return net, err

--- a/server/network.go
+++ b/server/network.go
@@ -235,7 +235,7 @@ func (lc *localNetwork) Start(ctx context.Context) error {
 	}
 
 	ux.Print(lc.log, logging.Blue.Wrap(logging.Bold.Wrap("create and run local network")))
-	nw, err := local.NewNetwork(lc.log, lc.cfg, lc.options.rootDataDir, lc.options.snapshotsDir, lc.options.reassignPortsIfUsed)
+	nw, err := local.NewNetwork(lc.log, lc.cfg, lc.options.rootDataDir, lc.options.snapshotsDir, lc.options.reassignPortsIfUsed, lc.options.redirectNodesOutput, lc.options.redirectNodesOutput)
 	if err != nil {
 		return err
 	}
@@ -519,6 +519,8 @@ func (lc *localNetwork) LoadSnapshot(snapshotName string) error {
 		lc.options.subnetConfigs,
 		globalNodeConfig,
 		lc.options.reassignPortsIfUsed,
+		lc.options.redirectNodesOutput,
+		lc.options.redirectNodesOutput,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Although the ANR was configured to output all logs to Stdout, newly created nodes would not do so. This is very useful for CI, where the log files are not accessible after a run failure.