### PR TITLE
Improve AvalancheGo and Plugin Path error messages

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,9 +22,9 @@ const (
 )
 
 var (
-	ErrEmptyExecPath    = errors.New("avalanche exec is not defined")
-	ErrNotExists        = errors.New("avalanche exec not exists")
-	ErrNotExistsPlugin  = errors.New("plugin exec not exists")
+	ErrEmptyExecPath    = errors.New("the path to the avalanchego executable is not defined. please make sure to either set the AVALANCHEGO_EXEC_PATH environment variable or pass the path with the --avalanchego-path flag")
+	ErrNotExists        = errors.New("the avalanchego executable does not exists at the provided path")
+	ErrNotExistsPlugin  = errors.New("the vm plugin does not exists at the provided path. please check if the plugin path is set correctly in the AVALANCHEGO_PLUGIN_PATH environment variable or the --plugin-dir flag and if the plugin binary is located there")
 	ErrorNoNetworkIDKey = fmt.Errorf("couldn't find key %q in genesis", genesisNetworkIDKey)
 )
 


### PR DESCRIPTION
The change improves the clarity of error messages related to the AvalancheGo executable and the VM plugin. The new error messages provide more detailed information and instructions to the user when the path to the AvalancheGo executable or the VM plugin is not defined or does not exist. 

### Open Question:

Why don't we check wether the `pluginExec` is empty, while we are checking it for the avalanchego exec path? Shouldn't we also have a `ErrEmptyPluginPath` error?

```go
var (
	ErrEmptyExecPath    = errors.New("the path to the avalanchego executable is not defined. please make sure to either set the AVALANCHEGO_EXEC_PATH environment variable or pass the path with the --avalanchego-path flag")
	ErrNotExists        = errors.New("the avalanchego executable does not exists at the provided path")
	ErrNotExistsPlugin  = errors.New("the vm plugin does not exists at the provided path. please check if the plugin path is set correctly in the AVALANCHEGO_PLUGIN_PATH environment variable or the --plugin-dir flag and if the plugin binary is located there")
	ErrorNoNetworkIDKey = fmt.Errorf("couldn't find key %q in genesis", genesisNetworkIDKey)
)

// ...

func CheckExecPath(exec string) error {
	if exec == "" {
		return ErrEmptyExecPath
	}
	_, err := os.Stat(exec)
	if err != nil {
		if errors.Is(err, fs.ErrNotExist) {
			return ErrNotExists
		}
		return fmt.Errorf("failed to stat exec %q (%w)", exec, err)
	}
	return nil
}

func CheckPluginPath(pluginExec string) error {
	var err error
	if _, err = os.Stat(pluginExec); err != nil {
		if errors.Is(err, fs.ErrNotExist) {
			return ErrNotExistsPlugin
		}
		return fmt.Errorf("failed to stat plugin exec %q (%w)", pluginExec, err)
	}

	return nil
}
```